### PR TITLE
Sanity checks

### DIFF
--- a/Server/net/minecraft/src/mod_AdditionalPipes.java
+++ b/Server/net/minecraft/src/mod_AdditionalPipes.java
@@ -175,19 +175,28 @@ public class mod_AdditionalPipes extends NetworkMod {
 
         // Liquid Teleport Pipe
         if (loadLiquidsTeleport) {
-            pipeLiquidTeleport = createPipe(LIQUID_TELEPORT_ID, PipeLiquidsTeleport.class, "Waterproof Teleport Pipe");
-            craftingmanager.addRecipe(
-                    new ItemStack(pipeLiquidTeleport, 1), new Object[]{
-                        "w", "P",
-                        Character.valueOf('w'), BuildCraftTransport.pipeWaterproof,
-                        Character.valueOf('P'), pipeItemTeleport});
+            if (loadItemTeleport) {
+                pipeLiquidTeleport = createPipe(LIQUID_TELEPORT_ID, PipeLiquidsTeleport.class, "Waterproof Teleport Pipe");
+                craftingmanager.addRecipe(
+                        new ItemStack(pipeLiquidTeleport, 1), new Object[]{
+                            "w", "P",
+                            Character.valueOf('w'), BuildCraftTransport.pipeWaterproof,
+                            Character.valueOf('P'), pipeItemTeleport});
+            } else {
+                ModLoader.getLogger().warning("Liquid Teleport Pipe cannot be enabled when Item Teleport Pipe is disabled.");
+            }
         }
 
         // Power Teleport Pipe
         if (loadPowerTeleport) {
-            pipePowerTeleport = createPipe(POWER_TELEPORT_ID, PipePowerTeleport.class, "Power Teleport Pipe");
-            craftingmanager.addRecipe(new ItemStack(pipePowerTeleport, 1), new Object[]{"r", "P", Character.valueOf('r'), Item.redstone, Character.valueOf('P'), pipeItemTeleport});
-        }
+            if (loadItemTeleport) {
+                pipePowerTeleport = createPipe(POWER_TELEPORT_ID, PipePowerTeleport.class, "Power Teleport Pipe");
+                craftingmanager.addRecipe(new ItemStack(pipePowerTeleport, 1), new Object[]{"r", "P", Character.valueOf('r'), Item.redstone, Character.valueOf('P'), pipeItemTeleport});
+                // Remove Redstone From Power TP Pipe
+                craftingmanager.addRecipe(new ItemStack(pipeItemTeleport, 1), new Object[]{"A", Character.valueOf('A'), pipePowerTeleport});
+            } else {
+                ModLoader.getLogger().warning("Power Teleport Pipe cannot be enabled when Item Teleport Pipe is disabled.");
+            }
 
         // Distributor Pipe
         if (loadItemsDistributor) {
@@ -218,9 +227,6 @@ public class mod_AdditionalPipes extends NetworkMod {
             pipeRedStoneLiquid = createPipe(RedStoneLiquid_ID, PipeLiquidsRedstone.class, "Waterproof Redstone Pipe");
             craftingmanager.addRecipe(new ItemStack(pipeRedStoneLiquid, 1), new Object[]{"w", "P", Character.valueOf('w'), BuildCraftTransport.pipeWaterproof, Character.valueOf('P'), pipeRedStone});
         }
-
-        // Remove Redstone From Power TP Pipe
-        craftingmanager.addRecipe(new ItemStack(pipeItemTeleport, 1), new Object[]{"A", Character.valueOf('A'), pipePowerTeleport});
 
         if (allowWPRemove) {
 


### PR DESCRIPTION
Add idiot-proofing to disabling the PipeItemTeleport and not the Liquids or Power Teleports and brought the reversal recipe for PipePowerTeleport into the loadPowerTeleport check.
